### PR TITLE
fix: build apps using the productive environment

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm install
       - run: npm run build
+        env:
+          NODE_ENV: production
         working-directory: ${{ matrix.app }}
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
We have noticed that on GitHub Actions, Parcel builds the host app
using the local environment config (.env) instead of the production one
(.env.production). When building the app locally, not on GitHub, it
works as expected. Actually, there should be no need to specify
`NODE_ENV=development` or `NODE_ENV=production` since that
is implied by Parcel's serve/watch or build, respectively.