### PR TITLE
chore: use tls for connecting to npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry = http://registry.npmjs.org
+registry = "https://registry.npmjs.org"


### PR DESCRIPTION
Beginning October 4, 2021, all connections to the npm registry -
including for package installation - must use TLS 1.2 or higher.
Further information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/