### PR TITLE
Issue/master/fix build

### DIFF
--- a/customers-app/package.json
+++ b/customers-app/package.json
@@ -10,20 +10,20 @@
   "dependencies": {
     "@scion/microfrontend-platform": "latest",
     "@scion/toolkit": "latest",
-    "rxjs": "^7.5.0"
+    "rxjs": "^7.5.7"
   },
   "devDependencies": {
-    "@parcel/transformer-sass": "^2.3.1",
-    "@types/node": "^15.6.1",
+    "@types/node": "^16.0.0",
     "copy-and-watch": "^0.1.6",
     "npm-run-all": "^4.1.5",
-    "parcel": "^2.3.1",
-    "typescript": "^4.6.0"
+    "parcel": "^2.7.0",
+    "typescript": "^4.8.4"
+  },
+  "alias": {
+    "process": false,
+    "@scion/toolkit/*": "./node_modules/@scion/toolkit/fesm2020/scion-toolkit-$1.mjs"
   },
   "browserslist": [
-    "last 2 Chrome versions"
-  ],
-  "alias": {
-    "process": false
-  }
+    "defaults"
+  ]
 }

--- a/customers-app/tsconfig.json
+++ b/customers-app/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   }

--- a/host-app/package.json
+++ b/host-app/package.json
@@ -10,20 +10,20 @@
   "dependencies": {
     "@scion/microfrontend-platform": "latest",
     "@scion/toolkit": "latest",
-    "rxjs": "^7.5.0"
+    "rxjs": "^7.5.7"
   },
   "devDependencies": {
-    "@parcel/transformer-sass": "^2.3.1",
-    "@types/node": "^15.6.1",
+    "@types/node": "^16.0.0",
     "copy-and-watch": "^0.1.6",
     "npm-run-all": "^4.1.5",
-    "parcel": "^2.3.1",
-    "typescript": "^4.6.0"
+    "parcel": "^2.7.0",
+    "typescript": "^4.8.4"
+  },
+  "alias": {
+    "process": false,
+    "@scion/toolkit/*": "./node_modules/@scion/toolkit/fesm2020/scion-toolkit-$1.mjs"
   },
   "browserslist": [
-    "last 2 Chrome versions"
-  ],
-  "alias": {
-    "process": false
-  }
+    "defaults"
+  ]
 }

--- a/host-app/tsconfig.json
+++ b/host-app/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
-    "types": [
-      "node"
-    ]
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "host-app:start": "npm start --prefix host-app",
     "products-app:start": "npm start --prefix products-app",
     "customers-app:start": "npm start --prefix customers-app",
+    "build": "run-s *:build",
+    "host-app:build": "npm run build --prefix host-app",
+    "products-app:build": "npm run build --prefix products-app",
+    "customers-app:build": "npm run build --prefix customers-app",
     "postinstall": "npm-recursive-install --skip-root"
   },
   "devDependencies": {

--- a/products-app/package.json
+++ b/products-app/package.json
@@ -10,20 +10,20 @@
   "dependencies": {
     "@scion/microfrontend-platform": "latest",
     "@scion/toolkit": "latest",
-    "rxjs": "^7.5.0"
+    "rxjs": "^7.5.7"
   },
   "devDependencies": {
-    "@parcel/transformer-sass": "^2.3.1",
-    "@types/node": "^15.6.1",
+    "@types/node": "^16.0.0",
     "copy-and-watch": "^0.1.6",
     "npm-run-all": "^4.1.5",
-    "parcel": "^2.3.1",
-    "typescript": "^4.6.0"
+    "parcel": "^2.7.0",
+    "typescript": "^4.8.4"
+  },
+  "alias": {
+    "process": false,
+    "@scion/toolkit/*": "./node_modules/@scion/toolkit/fesm2020/scion-toolkit-$1.mjs"
   },
   "browserslist": [
-    "last 2 Chrome versions"
-  ],
-  "alias": {
-    "process": false
-  }
+    "defaults"
+  ]
 }

--- a/products-app/tsconfig.json
+++ b/products-app/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   }


### PR DESCRIPTION
- **ci(build): fix Parcel build because SCION modules are published in ESM format**

  SCION packages are published exclusively as ESM modules (ECMAScript modules). For this reason, we have to instruct Parcel to use the ESM module system. Unfortunately, when using the ESM module system, Parcel does not yet support secondary entry points specified in the library's `package.json` via the `exports` field. As a workaround, we now specify package aliases in the application's `package.json` so Parcel can resolve secondary entry points. See https://github.com/parcel-bundler/parcel/issues/4155 for more information on this issue.

- **ci(build): add script to build all applications at once**
