### PR TITLE
[master] chore: move Getting Started Application to `*.scion.vercel.app` subdomain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,14 +15,14 @@ jobs:
           - products-app
           - customers-app
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm install
         working-directory: ${{ matrix.app }}
       - run: npm run build
         env:
           NODE_ENV: production
         working-directory: ${{ matrix.app }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.app }}
           path: ${{ matrix.app }}/dist
@@ -31,20 +31,20 @@ jobs:
     needs: [build-apps]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm install --ignore-scripts
       - name: 'Downloading host-app'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: host-app
           path: dist/host-app
       - name: 'Downloading products-app'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: products-app
           path: dist/products-app
       - name: 'Downloading customers-app'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: customers-app
           path: dist/customers-app

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,7 +55,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started.vercel.app
+          aliases: microfrontend-platform-getting-started.scion.vercel.app
       - name: 'Deploying products-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:
@@ -63,7 +63,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started-products-app.vercel.app
+          aliases: microfrontend-platform-getting-started-products-app.scion.vercel.app
       - name: 'Deploying customers-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:
@@ -71,4 +71,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started-customers-app.vercel.app
+          aliases: microfrontend-platform-getting-started-customers-app.scion.vercel.app

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ npm run start
 Pushing to the master branch triggers our GitHub workflow and deploys the sample application to [Vercel](https://vercel.com/scion/scion-microfrontend-platform-getting-started-app).
 
  - **Host Application (main entry point of the sample application)**\
-   https://scion-microfrontend-platform-getting-started.vercel.app
+   https://microfrontend-platform-getting-started.scion.vercel.app
  - **Products Application**\
-   https://scion-microfrontend-platform-getting-started-products-app.vercel.app
+   https://microfrontend-platform-getting-started-products-app.scion.vercel.app
  - **Customers Application**\
-   https://scion-microfrontend-platform-getting-started-customers-app.vercel.app
+   https://microfrontend-platform-getting-started-customers-app.scion.vercel.app
 
 ***
 
@@ -60,6 +60,6 @@ Pushing to the master branch triggers our GitHub workflow and deploys the sample
 
 [link-microfrontend-platform]: https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform
 [link-microfrontend-platform:getting-started-guide]: https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/docs/site/getting-started/getting-started.md
-[link-microfrontend-platform:getting-started-app]: https://scion-microfrontend-platform-getting-started.vercel.app
+[link-microfrontend-platform:getting-started-app]: https://microfrontend-platform-getting-started.scion.vercel.app
 [link-github-actions-workflow]: https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform-getting-started/actions
 [link-github-actions-workflow:status]: https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform-getting-started/workflows/Continuous%20Delivery/badge.svg?branch=master&event=push

--- a/host-app/.env
+++ b/host-app/.env
@@ -1,3 +1,3 @@
 PRODUCTS_APP_URL=http://localhost:4201
 CUSTOMERS_APP_URL=http://localhost:4202
-DEV_TOOLS_URL=https://scion-microfrontend-platform-devtools.vercel.app
+DEV_TOOLS_URL=https://microfrontend-platform-devtools.scion.vercel.app

--- a/host-app/.env.production
+++ b/host-app/.env.production
@@ -1,3 +1,3 @@
-PRODUCTS_APP_URL=https://scion-microfrontend-platform-getting-started-products-app.vercel.app
-CUSTOMERS_APP_URL=https://scion-microfrontend-platform-getting-started-customers-app.vercel.app
-DEV_TOOLS_URL=https://scion-microfrontend-platform-devtools.vercel.app
+PRODUCTS_APP_URL=https://microfrontend-platform-getting-started-products-app.scion.vercel.app
+CUSTOMERS_APP_URL=https://microfrontend-platform-getting-started-customers-app.scion.vercel.app
+DEV_TOOLS_URL=https://microfrontend-platform-devtools.scion.vercel.app


### PR DESCRIPTION
- Previous URL: https://scion-microfrontend-platform-getting-started.vercel.app
- New URL: https://microfrontend-platform-getting-started.scion.vercel.app