### PR TITLE
[master-angular] chore: move Getting Started Application to `*.scion.vercel.app` subdomain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ on:
       - 'issue/master-angular/**'
   workflow_dispatch:
 env:
-  NODE_VERSION: 20.9.0
+  NODE_VERSION: 20.14.0
 jobs:
   install:
     name: 'Installing NPM modules'
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: 'Caching NPM modules if necessary'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: node-modules-cache
         with:
           path: ./node_modules
@@ -43,12 +43,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: 'Restoring NPM modules from cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: node_modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - run: ${{ matrix.app.cmd }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.app.name }}
           path: dist/${{ matrix.app.name }}
@@ -59,17 +59,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Downloading host-app'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: host-app
           path: dist/host-app
       - name: 'Downloading products-app'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: products-app
           path: dist/products-app
       - name: 'Downloading customers-app'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: customers-app
           path: dist/customers-app

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,7 +80,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started-angular.vercel.app
+          aliases: microfrontend-platform-getting-started-angular.scion.vercel.app
       - name: 'Deploying products-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:
@@ -88,7 +88,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started-products-angular.vercel.app
+          aliases: microfrontend-platform-getting-started-products-angular.scion.vercel.app
       - name: 'Deploying customers-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:
@@ -96,4 +96,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_MICROFRONTEND_PLATFORM_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-microfrontend-platform-getting-started-customers-angular.vercel.app
+          aliases: microfrontend-platform-getting-started-customers-angular.scion.vercel.app

--- a/apps/host-app/src/environments/environment.prod.ts
+++ b/apps/host-app/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   PRODUCTS_APP_MANIFEST_URL: 'http://localhost:4201/assets/manifest.json',
   CUSTOMERS_APP_MANIFEST_URL: 'http://localhost:4202/assets/manifest.json',
-  DEV_TOOLS_MANIFEST_URL: 'https://scion-microfrontend-platform-devtools.vercel.app/assets/manifest.json',
+  DEV_TOOLS_MANIFEST_URL: 'https://microfrontend-platform-devtools.scion.vercel.app/assets/manifest.json',
 };

--- a/apps/host-app/src/environments/environment.prod.vercel.ts
+++ b/apps/host-app/src/environments/environment.prod.vercel.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  PRODUCTS_APP_MANIFEST_URL: 'https://scion-microfrontend-platform-getting-started-products-angular.vercel.app/assets/manifest.json',
-  CUSTOMERS_APP_MANIFEST_URL: 'https://scion-microfrontend-platform-getting-started-customers-angular.vercel.app/assets/manifest.json',
-  DEV_TOOLS_MANIFEST_URL: 'https://scion-microfrontend-platform-devtools.vercel.app/assets/manifest.json',
+  PRODUCTS_APP_MANIFEST_URL: 'https://microfrontend-platform-getting-started-products-angular.scion.vercel.app/assets/manifest.json',
+  CUSTOMERS_APP_MANIFEST_URL: 'https://microfrontend-platform-getting-started-customers-angular.scion.vercel.app/assets/manifest.json',
+  DEV_TOOLS_MANIFEST_URL: 'https://microfrontend-platform-devtools.scion.vercel.app/assets/manifest.json',
 };

--- a/apps/host-app/src/environments/environment.ts
+++ b/apps/host-app/src/environments/environment.ts
@@ -5,5 +5,5 @@
 export const environment = {
   PRODUCTS_APP_MANIFEST_URL: 'http://localhost:4201/assets/manifest.json',
   CUSTOMERS_APP_MANIFEST_URL: 'http://localhost:4202/assets/manifest.json',
-  DEV_TOOLS_MANIFEST_URL: 'https://scion-microfrontend-platform-devtools.vercel.app/assets/manifest.json',
+  DEV_TOOLS_MANIFEST_URL: 'https://microfrontend-platform-devtools.scion.vercel.app/assets/manifest.json',
 };


### PR DESCRIPTION
Previous URL: https://scion-microfrontend-platform-getting-started-angular.vercel.app
New URL: https://microfrontend-platform-getting-started-angular.scion.vercel.app